### PR TITLE
[Feat] #13 - 카페 태그 및 상세 정보(리뷰, 운영시간) 구글맵 api 연동

### DIFF
--- a/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
@@ -11,8 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -61,7 +59,13 @@ public class CafeController {
         List<Cafe> cafes = cafeService.searchCafeByKeyword(query);
 
         List<CafeSearchDTO> dtos = cafes.stream()
-                .map(cafe -> new CafeSearchDTO(cafe.getCafeId(), cafe.getCafeName(), cafe.getAddress()))
+                .map(cafe -> new CafeSearchDTO(
+                        cafe.getCafeId(),
+                        cafe.getCafeName(),
+                        cafe.getAddress(),
+                        cafe.getLatitude(),
+                        cafe.getLongitude()
+                ))
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(dtos);

--- a/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
@@ -40,6 +40,8 @@ public class CafeController {
                 cafe.getWebsiteUrl(),
                 cafe.getUpdateAt(),
                 cafe.getAverageRating(),
+                cafe.getOpeningHours(),
+                cafe.getPhotoUrl(),
                 cafe.getWifi(),
                 cafe.getOutlets(),
                 cafe.getDesk(),

--- a/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
@@ -1,6 +1,8 @@
 package com.Minjin.TagCafe.controller;
 
 import com.Minjin.TagCafe.dto.CafeDto;
+import com.Minjin.TagCafe.dto.CafeHomeDTO;
+import com.Minjin.TagCafe.dto.CafeSearchDTO;
 import com.Minjin.TagCafe.entity.Cafe;
 import com.Minjin.TagCafe.repository.CafeRepository;
 import com.Minjin.TagCafe.service.CafeService;
@@ -55,23 +57,52 @@ public class CafeController {
 
     // 검색
     @GetMapping("/search")
-    public ResponseEntity<List<Cafe>> searchCafe(@RequestParam(name = "query") String query) {
-        return ResponseEntity.ok(cafeService.searchCafeByKeyword(query));
+    public ResponseEntity<List<CafeSearchDTO>> searchCafe(@RequestParam(name = "query") String query) {
+        List<Cafe> cafes = cafeService.searchCafeByKeyword(query);
+
+        List<CafeSearchDTO> dtos = cafes.stream()
+                .map(cafe -> new CafeSearchDTO(cafe.getCafeId(), cafe.getCafeName(), cafe.getAddress()))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(dtos);
     }
 
     // 지도 영역 내 카페 조회 (위경도 범위 내 검색)
     @GetMapping("/area")
-    public ResponseEntity<List<Cafe>> getCafesInArea(@RequestParam(name = "minLat") double minLat,
-                                                     @RequestParam(name = "maxLat") double maxLat,
-                                                     @RequestParam(name = "minLng") double minLng,
-                                                     @RequestParam(name = "maxLng") double maxLng) {
+    public ResponseEntity<List<CafeHomeDTO>> getCafesInArea(@RequestParam(name = "minLat") double minLat,
+                                                            @RequestParam(name = "maxLat") double maxLat,
+                                                            @RequestParam(name = "minLng") double minLng,
+                                                            @RequestParam(name = "maxLng") double maxLng) {
         List<Cafe> cafes = cafeService.getCafesInArea(minLat, maxLat, minLng, maxLng);
-        return ResponseEntity.ok(cafes);
+
+        List<CafeHomeDTO> dtos = cafes.stream()
+                .map(cafe -> {
+                    String imageBase64 = cafe.getImages().isEmpty() ? null
+                            : Base64.getEncoder().encodeToString(cafe.getImages().get(0).getImageData());
+                    return new CafeHomeDTO(
+                            cafe.getCafeId(),
+                            cafe.getCafeName(),
+                            cafe.getLatitude(),
+                            cafe.getLongitude(),
+                            cafe.getAddress(),
+                            cafe.getAverageRating(),
+                            cafe.getOpeningHours(),
+                            cafe.getWifi(),
+                            cafe.getOutlets(),
+                            cafe.getDesk(),
+                            cafe.getRestroom(),
+                            cafe.getParking(),
+                            imageBase64
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(dtos);
     }
 
     // 특정 태그와 특정 값을 가진 카페 조회
     @GetMapping("/filter")
-    public ResponseEntity<List<Cafe>> getCafesByMultipleTags(@RequestParam(name = "tagNames") List<String> tagNames,
+    public ResponseEntity<List<CafeHomeDTO>> getCafesByMultipleTags(@RequestParam(name = "tagNames") List<String> tagNames,
                                                              @RequestParam(name = "values") List<String> values) {
         if (tagNames.size() != values.size()) {
             return ResponseEntity.badRequest().build();
@@ -89,7 +120,30 @@ public class CafeController {
         }
 
         List<Cafe> cafes = cafeService.getCafesByMultipleTagsAndValues(tagNames, values);
-        return ResponseEntity.ok(cafes);
+
+        List<CafeHomeDTO> dtos = cafes.stream().map(cafe -> {
+            String imageBase64 = cafe.getImages() != null && !cafe.getImages().isEmpty()
+                    ? Base64.getEncoder().encodeToString(cafe.getImages().get(0).getImageData())
+                    : null;
+
+            return new CafeHomeDTO(
+                    cafe.getCafeId(),
+                    cafe.getCafeName(),
+                    cafe.getLatitude(),
+                    cafe.getLongitude(),
+                    cafe.getAddress(),
+                    cafe.getAverageRating(),
+                    cafe.getOpeningHours(),
+                    cafe.getWifi(),
+                    cafe.getOutlets(),
+                    cafe.getDesk(),
+                    cafe.getRestroom(),
+                    cafe.getParking(),
+                    imageBase64
+            );
+        }).collect(Collectors.toList());
+
+        return ResponseEntity.ok(dtos);
     }
 
 

--- a/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
@@ -12,10 +12,8 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/cafes")
@@ -29,6 +27,9 @@ public class CafeController {
     @GetMapping("/{cafeId}")
     public ResponseEntity<CafeDto> getCafeById(@PathVariable("cafeId") Long cafeId) {
         Cafe cafe = cafeService.getCafeById(cafeId);
+        List<String> base64Images = cafe.getImages().stream()
+                .map(image -> Base64.getEncoder().encodeToString(image.getImageData()))
+                .collect(Collectors.toList());
         CafeDto cafeDto = new CafeDto(
                 cafe.getCafeId(),
                 cafe.getKakaoPlaceId(),
@@ -41,12 +42,13 @@ public class CafeController {
                 cafe.getUpdateAt(),
                 cafe.getAverageRating(),
                 cafe.getOpeningHours(),
-                cafe.getPhotoUrl(),
                 cafe.getWifi(),
                 cafe.getOutlets(),
                 cafe.getDesk(),
                 cafe.getRestroom(),
-                cafe.getParking()
+                cafe.getParking(),
+                null,
+                base64Images
         );
         return ResponseEntity.ok(cafeDto);
     }

--- a/src/main/java/com/Minjin/TagCafe/controller/ReportedCafeController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/ReportedCafeController.java
@@ -1,6 +1,7 @@
 package com.Minjin.TagCafe.controller;
 
 import com.Minjin.TagCafe.dto.PhotoUrlsRequest;
+import com.Minjin.TagCafe.dto.ReportedCafeDTO;
 import com.Minjin.TagCafe.entity.*;
 import com.Minjin.TagCafe.repository.ReportedCafeRepository;
 import com.Minjin.TagCafe.repository.ReviewRepository;
@@ -37,9 +38,12 @@ public class ReportedCafeController {
     }
 
     @GetMapping("/user/{userEmail}")
-    public ResponseEntity<List<ReportedCafe>> getReportsByUser(@PathVariable("userEmail") String userEmail) {
+    public ResponseEntity<List<ReportedCafeDTO>> getReportsByUser(@PathVariable("userEmail") String userEmail) {
         List<ReportedCafe> reports = reportedCafeService.getReportsByUser(userEmail);
-        return ResponseEntity.ok(reports);
+        List<ReportedCafeDTO> dtos = reports.stream()
+                .map(ReportedCafeDTO::fromEntity)
+                .toList();
+        return ResponseEntity.ok(dtos);
     }
     @GetMapping("/{id}")
     public ResponseEntity<ReportedCafe> getReportedCafe(@PathVariable("id") Long id) {
@@ -85,9 +89,13 @@ public class ReportedCafeController {
 
     // 모든 제보 목록 조회
     @GetMapping("/admin/all")
-    public ResponseEntity<List<ReportedCafe>> getAllReports() {
-        List<ReportedCafe> allReports = reportedCafeRepository.findAll();
-        return ResponseEntity.ok(allReports);
+    public ResponseEntity<List<ReportedCafeDTO>> getAllReports() {
+        List<ReportedCafe> reports = reportedCafeRepository.findAll();
+        List<ReportedCafeDTO> dtos = reports.stream()
+                .map(ReportedCafeDTO::fromEntity)
+                .toList();
+
+        return ResponseEntity.ok(dtos);
     }
     //제보 승인
     @PostMapping("/admin/approve/{id}")

--- a/src/main/java/com/Minjin/TagCafe/controller/ReviewController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/ReviewController.java
@@ -29,7 +29,7 @@ public class ReviewController {
     }
 
     @GetMapping("/{cafeId}")
-    public ResponseEntity<List<Review>> getReviewsByCafe(@PathVariable("cafeId") Long cafeId) {
+    public ResponseEntity<List<ReviewDTO>> getReviewsByCafe(@PathVariable("cafeId") Long cafeId) {
         return ResponseEntity.ok(reviewService.getReviewsByCafeId(cafeId));
     }
 }

--- a/src/main/java/com/Minjin/TagCafe/controller/SavedCafeController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/SavedCafeController.java
@@ -1,6 +1,7 @@
 package com.Minjin.TagCafe.controller;
 
 import com.Minjin.TagCafe.dto.SavedCafeDTO;
+import com.Minjin.TagCafe.entity.Cafe;
 import com.Minjin.TagCafe.entity.SavedCafe;
 import com.Minjin.TagCafe.service.SavedCafeService;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +34,15 @@ public class SavedCafeController {
 
     // 방문여부 업데이트
     @PatchMapping("/{cafeId}/visited")
-    public ResponseEntity<SavedCafe> toggleVisited(
+    public ResponseEntity<SavedCafeDTO> toggleVisited(
             @RequestParam("userId") Long userId,
             @PathVariable("cafeId") Long cafeId) {
 
-        return ResponseEntity.ok(savedCafeService.toggleVisitedStatus(userId, cafeId));
+        SavedCafe savedCafe = savedCafeService.toggleVisitedStatus(userId, cafeId);
+        Cafe cafe = savedCafe.getCafe();
+        Boolean visited = savedCafe.getVisited();
+
+        return ResponseEntity.ok(new SavedCafeDTO(cafe, visited));
     }
 
     // 저장한 카페 목록 + 필터링 적용

--- a/src/main/java/com/Minjin/TagCafe/dto/CafeDto.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/CafeDto.java
@@ -21,8 +21,8 @@ public class CafeDto {
     private String websiteUrl;
     private LocalDateTime updateAt;
     private double averageRating;
-    private String photoUrl;
     private String openingHours;
+    private String photoUrl;
 
     private CafeAttributes.WifiSpeed wifi;
     private CafeAttributes.OutletAvailability outlets;

--- a/src/main/java/com/Minjin/TagCafe/dto/CafeDto.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/CafeDto.java
@@ -21,6 +21,8 @@ public class CafeDto {
     private String websiteUrl;
     private LocalDateTime updateAt;
     private double averageRating;
+    private String photoUrl;
+    private String openingHours;
 
     private CafeAttributes.WifiSpeed wifi;
     private CafeAttributes.OutletAvailability outlets;

--- a/src/main/java/com/Minjin/TagCafe/dto/CafeDto.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/CafeDto.java
@@ -4,6 +4,7 @@ import com.Minjin.TagCafe.entity.enums.CafeAttributes;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Getter
@@ -22,11 +23,14 @@ public class CafeDto {
     private LocalDateTime updateAt;
     private double averageRating;
     private String openingHours;
-    private String photoUrl;
 
     private CafeAttributes.WifiSpeed wifi;
     private CafeAttributes.OutletAvailability outlets;
     private CafeAttributes.DeskSize desk;
     private CafeAttributes.RestroomAvailability restroom;
     private CafeAttributes.ParkingAvailability parking;
+
+    private List<String> photoUrls;
+    private List<String> imageBase64List;
+
 }

--- a/src/main/java/com/Minjin/TagCafe/dto/CafeHomeDTO.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/CafeHomeDTO.java
@@ -1,0 +1,27 @@
+package com.Minjin.TagCafe.dto;
+
+import com.Minjin.TagCafe.entity.enums.CafeAttributes;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CafeHomeDTO {
+    private Long cafeId;
+    private String cafeName;
+    private double latitude;
+    private double longitude;
+    private String address;
+    private double averageRating;
+    private String openingHours;
+
+    private CafeAttributes.WifiSpeed wifi;
+    private CafeAttributes.OutletAvailability outlets;
+    private CafeAttributes.DeskSize desk;
+    private CafeAttributes.RestroomAvailability restroom;
+    private CafeAttributes.ParkingAvailability parking;
+
+    private String thumbnailImageBase64;  // 대표 이미지 1장
+}

--- a/src/main/java/com/Minjin/TagCafe/dto/CafeSearchDTO.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/CafeSearchDTO.java
@@ -1,0 +1,15 @@
+package com.Minjin.TagCafe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CafeSearchDTO {
+    private Long cafeId;
+    private String cafeName;
+    private String address;
+
+}

--- a/src/main/java/com/Minjin/TagCafe/dto/CafeSearchDTO.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/CafeSearchDTO.java
@@ -11,5 +11,7 @@ public class CafeSearchDTO {
     private Long cafeId;
     private String cafeName;
     private String address;
+    private double latitude;
+    private double longitude;
 
 }

--- a/src/main/java/com/Minjin/TagCafe/dto/PhotoUrlsRequest.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/PhotoUrlsRequest.java
@@ -1,0 +1,10 @@
+package com.Minjin.TagCafe.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PhotoUrlsRequest {
+    private List<String> photoUrls;
+}

--- a/src/main/java/com/Minjin/TagCafe/dto/ReportedCafeDTO.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/ReportedCafeDTO.java
@@ -1,0 +1,45 @@
+package com.Minjin.TagCafe.dto;
+
+import com.Minjin.TagCafe.entity.ReportedCafe;
+import com.Minjin.TagCafe.entity.enums.CafeAttributes;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReportedCafeDTO {
+    private Long reportedCafeId;
+    private String userEmail;
+    private String cafeName;
+    private String address;
+    private String kakaoPlaceId;
+    private CafeAttributes.WifiSpeed wifi;
+    private CafeAttributes.OutletAvailability outlets;
+    private CafeAttributes.DeskSize desk;
+    private CafeAttributes.RestroomAvailability restroom;
+    private CafeAttributes.ParkingAvailability parking;
+    private String content;
+    private String status;
+    private Long cafeId;
+
+    public static ReportedCafeDTO fromEntity(ReportedCafe report) {
+        return ReportedCafeDTO.builder()
+                .reportedCafeId(report.getReportedCafeId())
+                .userEmail(report.getUserEmail())
+                .cafeName(report.getCafeName())
+                .address(report.getAddress())
+                .kakaoPlaceId(report.getKakaoPlaceId())
+                .wifi(report.getWifi())
+                .outlets(report.getOutlets())
+                .desk(report.getDesk())
+                .restroom(report.getRestroom())
+                .parking(report.getParking())
+                .content(report.getContent())
+                .status(report.getStatus().name())
+                .cafeId(report.getCafe() != null ? report.getCafe().getCafeId() : null)
+                .build();
+    }
+
+}
+
+

--- a/src/main/java/com/Minjin/TagCafe/dto/ReviewDTO.java
+++ b/src/main/java/com/Minjin/TagCafe/dto/ReviewDTO.java
@@ -19,6 +19,7 @@ public class ReviewDTO {
     private Long cafeId;
     private String cafeName;
     private String userEmail;
+    private String userNickname;
     private int rating;
     private String content;
 
@@ -31,11 +32,12 @@ public class ReviewDTO {
     private LocalDateTime createdAt;
 
     // Review 객체를 받을 수 있도록 생성자 추가
-    public ReviewDTO(Review review) {
+    public ReviewDTO(Review review, String nickname) {
         this.reviewId=review.getId();
         this.cafeId = review.getCafe().getCafeId();
         this.cafeName = review.getCafe().getCafeName();
         this.userEmail = review.getUserEmail();
+        this.userNickname = nickname;
         this.rating = review.getRating();
         this.content = review.getContent();
         this.wifi = review.getWifi();
@@ -43,5 +45,6 @@ public class ReviewDTO {
         this.desk = review.getDesk();
         this.restroom = review.getRestroom();
         this.parking = review.getParking();
+        this.createdAt = review.getCreatedAt();
     }
 }

--- a/src/main/java/com/Minjin/TagCafe/entity/Cafe.java
+++ b/src/main/java/com/Minjin/TagCafe/entity/Cafe.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 
 @Entity
 @Table(name = "Cafe",
@@ -39,9 +40,6 @@ public class Cafe {
     private String phoneNumber;
     private String websiteUrl;
 
-    @Column(length = 1000)
-    private String photoUrl;
-
     @UpdateTimestamp
     private LocalDateTime updateAt;
 
@@ -67,6 +65,9 @@ public class Cafe {
     @Enumerated(EnumType.STRING)
     @Column
     private CafeAttributes.ParkingAvailability parking;
+
+    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, orphanRemoval = true)
+    private java.util.List<CafeImage> images = new ArrayList<>();
 
 
     public Cafe(Long kakaoPlaceId, String cafeName, double latitude, double longitude, String address, String phoneNumber, String websiteUrl) {

--- a/src/main/java/com/Minjin/TagCafe/entity/Cafe.java
+++ b/src/main/java/com/Minjin/TagCafe/entity/Cafe.java
@@ -39,6 +39,9 @@ public class Cafe {
     private String phoneNumber;
     private String websiteUrl;
 
+    @Column(length = 1000)
+    private String photoUrl;
+
     @UpdateTimestamp
     private LocalDateTime updateAt;
 

--- a/src/main/java/com/Minjin/TagCafe/entity/CafeImage.java
+++ b/src/main/java/com/Minjin/TagCafe/entity/CafeImage.java
@@ -1,0 +1,24 @@
+package com.Minjin.TagCafe.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CafeImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    @Column(name = "image_data", nullable = false, columnDefinition = "LONGBLOB")
+    private byte[] imageData; // 이미지 바이너리
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    private Cafe cafe;
+}

--- a/src/main/java/com/Minjin/TagCafe/entity/ReportedCafe.java
+++ b/src/main/java/com/Minjin/TagCafe/entity/ReportedCafe.java
@@ -32,6 +32,8 @@ public class ReportedCafe {
 
     private String kakaoPlaceId;
 
+    private String googlePlaceId;
+
     private Double latitude;
 
     private Double longitude;

--- a/src/main/java/com/Minjin/TagCafe/repository/CafeImageRepository.java
+++ b/src/main/java/com/Minjin/TagCafe/repository/CafeImageRepository.java
@@ -1,0 +1,7 @@
+package com.Minjin.TagCafe.repository;
+
+import com.Minjin.TagCafe.entity.CafeImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
+}

--- a/src/main/java/com/Minjin/TagCafe/service/CafeService.java
+++ b/src/main/java/com/Minjin/TagCafe/service/CafeService.java
@@ -65,8 +65,12 @@ public class CafeService {
         for (String line : lines) {
             if (!line.startsWith(todayKor)) continue;
 
+            if (line.contains("휴무일")) {
+                return false;
+            }
+
             if (line.contains("24시간 영업")) {
-                return true; // 항상 영업중
+                return true;
             }
 
             String[] parts = line.split(": ");
@@ -81,7 +85,6 @@ public class CafeService {
 
             return nowTime.isAfter(start) && nowTime.isBefore(end);
         }
-
         return false;
     }
 

--- a/src/main/java/com/Minjin/TagCafe/service/CafeService.java
+++ b/src/main/java/com/Minjin/TagCafe/service/CafeService.java
@@ -236,7 +236,7 @@ public class CafeService {
         return cafeRepository.findAll();
     }
 
-    private byte[] fetchImageAsBytes(String imageUrl) {
+    public byte[] fetchImageAsBytes(String imageUrl) {
         if (imageUrl == null || imageUrl.contains("undefined")) {
             throw new RuntimeException("잘못된 이미지 URL: " + imageUrl);
         }

--- a/src/main/java/com/Minjin/TagCafe/service/CafeService.java
+++ b/src/main/java/com/Minjin/TagCafe/service/CafeService.java
@@ -112,15 +112,17 @@ public class CafeService {
             throw new RuntimeException("이미 존재하는 카페입니다.");
         }
 
-        Cafe cafe = new Cafe(
-                cafeDto.getKakaoPlaceId(),
-                cafeDto.getCafeName(),
-                cafeDto.getLatitude(),
-                cafeDto.getLongitude(),
-                cafeDto.getAddress(),
-                cafeDto.getPhoneNumber(),
-                cafeDto.getWebsiteUrl()
-        );
+        Cafe cafe = Cafe.builder()
+                .kakaoPlaceId(cafeDto.getKakaoPlaceId())
+                .cafeName(cafeDto.getCafeName())
+                .latitude(cafeDto.getLatitude())
+                .longitude(cafeDto.getLongitude())
+                .address(cafeDto.getAddress())
+                .phoneNumber(cafeDto.getPhoneNumber())
+                .websiteUrl(cafeDto.getWebsiteUrl())
+                .openingHours(cafeDto.getOpeningHours())
+                .photoUrl(cafeDto.getPhotoUrl())
+                .build();
 
         return cafeRepository.save(cafe);
     }

--- a/src/main/java/com/Minjin/TagCafe/service/ReviewService.java
+++ b/src/main/java/com/Minjin/TagCafe/service/ReviewService.java
@@ -198,7 +198,10 @@ public class ReviewService {
         }
 
         return reviews.stream()
-                .map(ReviewDTO::new)
+                .map(review -> {
+                    String nickname = userService.getNicknameByEmail(review.getUserEmail());
+                    return new ReviewDTO(review, nickname);
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/Minjin/TagCafe/service/ReviewService.java
+++ b/src/main/java/com/Minjin/TagCafe/service/ReviewService.java
@@ -8,7 +8,6 @@ import com.Minjin.TagCafe.repository.ReviewRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -17,10 +16,12 @@ import java.util.stream.Collectors;
 public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final CafeRepository cafeRepository;
+    private final UserService userService;
 
-    public ReviewService(ReviewRepository reviewRepository, CafeRepository cafeRepository) {
+    public ReviewService(ReviewRepository reviewRepository, CafeRepository cafeRepository, UserService userService) {
         this.reviewRepository = reviewRepository;
         this.cafeRepository = cafeRepository;
+        this.userService = userService;
     }
 
     @Transactional
@@ -51,38 +52,34 @@ public class ReviewService {
         updateCafeTags(cafe);
     }
 
-    public List<Review> getReviewsByCafeId(Long cafeId) {
-        return reviewRepository.findByCafe_CafeId(cafeId);
+    public List<ReviewDTO> getReviewsByCafeId(Long cafeId) {
+        List<Review> reviews = reviewRepository.findByCafe_CafeId(cafeId);
+
+        return reviews.stream().map(review -> {
+            String nickname = userService.getNicknameByEmail(review.getUserEmail());
+            return new ReviewDTO(review, nickname);
+        }).collect(Collectors.toList());
     }
 
     public List<ReviewDTO> getReviewsByUser(String userEmail) {
         List<Review> reviews = reviewRepository.findByUserEmail(userEmail);
+        String nickname = userService.getNicknameByEmail(userEmail);
 
         return reviews.stream().map(review -> {
             Cafe cafe = review.getCafe();  //Review에서 직접 Cafe 객체 가져오기
             String cafeName = (cafe != null) ? cafe.getCafeName() : "알 수 없는 카페";
 
-            return new ReviewDTO(
-                    review.getId(),
-                    review.getCafe().getCafeId(),
-                    cafeName,
-                    review.getUserEmail(),
-                    review.getRating(),
-                    review.getContent(),
-                    review.getWifi(),
-                    review.getOutlets(),
-                    review.getDesk(),
-                    review.getRestroom(),
-                    review.getParking(),
-                    review.getCreatedAt()
-            );
+            ReviewDTO dto = new ReviewDTO(review, nickname);
+            dto.setCafeName(cafeName);
+            return dto;
         }).collect(Collectors.toList());
     }
 
     public ReviewDTO getReviewById(Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 존재하지 않습니다."));
-        return new ReviewDTO(review);
+        String nickname = userService.getNicknameByEmail(review.getUserEmail());
+        return new ReviewDTO(review, nickname);
     }
 
     @Transactional
@@ -160,35 +157,4 @@ public class ReviewService {
         cafeRepository.save(cafe);
     }
 
-    /**
-     * 특정 카페의 모든 리뷰에서 태그 빈도 분석
-
-    public Map<String, Long> getCafeTagStatistics(Long cafeId) {
-        List<Review> reviews = reviewRepository.findByCafeId(cafeId);
-
-        Map<String, Long> tagCount = new HashMap<>();
-
-        tagCount.put("wifi_빠름", reviews.stream().filter(r -> r.getWifi() == WifiSpeed.빠름).count());
-        tagCount.put("wifi_보통", reviews.stream().filter(r -> r.getWifi() == WifiSpeed.보통).count());
-        tagCount.put("wifi_없음", reviews.stream().filter(r -> r.getWifi() == WifiSpeed.없음).count());
-
-        tagCount.put("outlets_자리마다", reviews.stream().filter(r -> r.getOutlets() == OutletAvailability.자리마다).count());
-        tagCount.put("outlets_일부", reviews.stream().filter(r -> r.getOutlets() == OutletAvailability.일부).count());
-        tagCount.put("outlets_없음", reviews.stream().filter(r -> r.getOutlets() == OutletAvailability.없음).count());
-
-        tagCount.put("desk_넓음", reviews.stream().filter(r -> r.getDesk() == DeskSize.넓음).count());
-        tagCount.put("desk_적당함", reviews.stream().filter(r -> r.getDesk() == DeskSize.적당함).count());
-        tagCount.put("desk_좁음", reviews.stream().filter(r -> r.getDesk() == DeskSize.좁음).count());
-
-        tagCount.put("restroom_가능", reviews.stream().filter(r -> r.getRestroom() == RestroomAvailability.가능).count());
-        tagCount.put("restroom_불가능", reviews.stream().filter(r -> r.getRestroom() == RestroomAvailability.불가능).count());
-
-        tagCount.put("parking_가능_무료", reviews.stream().filter(r -> r.getParking() == ParkingAvailability.가능_무료).count());
-        tagCount.put("parking_가능_유료", reviews.stream().filter(r -> r.getParking() == ParkingAvailability.가능_유료).count());
-        tagCount.put("parking_가능_일부제공", reviews.stream().filter(r -> r.getParking() == ParkingAvailability.가능_일부제공).count());
-        tagCount.put("parking_불가능", reviews.stream().filter(r -> r.getParking() == ParkingAvailability.불가능).count());
-
-        return tagCount;
-    }
-     */
 }

--- a/src/main/java/com/Minjin/TagCafe/service/UserService.java
+++ b/src/main/java/com/Minjin/TagCafe/service/UserService.java
@@ -30,4 +30,12 @@ public class UserService {
         // ✅ JWT 생성 후 반환
         return jwtUtil.generateToken(user.getEmail());
     }
+
+    // 이메일로 닉네임 조회
+    public String getNicknameByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .map(User::getNickname)
+                .orElse("알 수 없음");
+    }
+
 }


### PR DESCRIPTION
### Pull request
⛳️ 작업한 브랜치
- feat/# 13-cafe-info-update

👷 작업한 내용

**리뷰 기능 개선**
- 리뷰 추가/수정/삭제 시 카페 평균 평점 자동 업데이트
- 리뷰 CRUD 시 태그 최빈값으로 Cafe 태그 자동 반영
- 리뷰 작성자 이메일 대신 닉네임 표시 (UserService 연동)

**Cafe 정보 확장**
- CafeDto에 averageRating 필드 추가
- Google Map API에서 운영시간, 웹사이트 URL 받아온 정보 저장
- Google Map API 기반 이미지 저장 기능 구현 (CafeImage)
- 변수명 grade → rating 으로 변경

**검색 및 필터 기능 개선**
- 운영시간 필터링 기능 추가 (`영업중`, `24시간`)
- '휴무일' 포함 운영시간 정상 처리
- 홈,필터/검색 응답을 Cafe에서 각각 CafeHomeDTO/CafeSearchDTO 로 변경하여 JSON 파싱 오류 해결

### 스크린샷
|기능|스크린샷|
|---|--------|
|홈-영업시간 필터링|![home-filtering](https://github.com/user-attachments/assets/ed3fd268-8497-4761-8629-b12b52d8b312)|
|저장-영업시간 필터링|![saved_filtering](https://github.com/user-attachments/assets/5594b91f-124d-471b-baa4-8320a1e4bf8f)|
|카페 상세페이지 이미지 있을 때|![detail-image](https://github.com/user-attachments/assets/e369bdef-5044-47c2-897e-6f507c07527b)|
|리뷰에 따라 별점, 태그 업데이트|![review_rating-tag-update](https://github.com/user-attachments/assets/fd1c0d4b-402a-4ae7-afc4-b5f09dc178ba)|


### 관련 이슈
- #13