### PR TITLE
[fix] #25 - 회원 로직 및 배포 프로세스 픽스

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           source: "build/libs/TagCafe-0.0.1-SNAPSHOT.jar"
           target: "/home/ec2-user/app/"
+          overwrite: true
 
       - name: SSH into EC2 and deploy
         uses: appleboy/ssh-action@v0.1.10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,14 +14,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Copy files to EC2
+      - name: Build JAR
+        run: ./gradlew clean build -x test
+
+      - name: Copy JAR to EC2
         uses: appleboy/scp-action@v0.1.3
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_KEY }}
-          source: "."
-          target: "/home/ec2-user/app"
+          source: "build/libs/app.jar"
+          target: "/home/ec2-user/app/build/libs/"
 
       - name: SSH into EC2 and deploy
         uses: appleboy/ssh-action@v0.1.10
@@ -31,7 +34,5 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           script: |
             cd /home/ec2-user/app
-            chmod +x gradlew
-            ./gradlew clean build -x test
             docker-compose down
-            docker-compose up --build -d
+            docker-compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           username: ec2-user
           key: ${{ secrets.EC2_KEY }}
           source: "build/libs/TagCafe-0.0.1-SNAPSHOT.jar"
-          target: "/home/ec2-user/app/app.jar"
+          target: "/home/ec2-user/app/"
 
       - name: SSH into EC2 and deploy
         uses: appleboy/ssh-action@v0.1.10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "${{ secrets.EC2_KEY }}" > key.pem
           chmod 600 key.pem
-          scp -i key.pem -o StrictHostKeyChecking=no build/libs/TagCafe-0.0.1-SNAPSHOT.jar ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/app/
+          scp -i key.pem -o StrictHostKeyChecking=no build/libs/TagCafe-0.0.1-SNAPSHOT.jar ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/app/TagCafe-0.0.1-SNAPSHOT.jar
 
       - name: SSH into EC2 and deploy
         uses: appleboy/ssh-action@v0.1.10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_KEY }}
-          source: "build/libs/app.jar"
+          source: "build/libs/TagCafe-0.0.1-SNAPSHOT.jar"
           target: "/home/ec2-user/app/build/libs/"
 
       - name: SSH into EC2 and deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,8 @@ jobs:
       - name: Build JAR
         run: ./gradlew clean build -x test
 
-      - name: Copy JAR to EC2 manually
-        run: |
-          echo "${{ secrets.EC2_KEY }}" > key.pem
-          chmod 600 key.pem
-          scp -i key.pem -o StrictHostKeyChecking=no build/libs/TagCafe-0.0.1-SNAPSHOT.jar ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/app/TagCafe-0.0.1-SNAPSHOT.jar
+      - name: Copy jar to Docker context
+        run: cp build/libs/TagCafe-0.0.1-SNAPSHOT.jar .
 
       - name: SSH into EC2 and deploy
         uses: appleboy/ssh-action@v0.1.10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           username: ec2-user
           key: ${{ secrets.EC2_KEY }}
           source: "build/libs/TagCafe-0.0.1-SNAPSHOT.jar"
-          target: "/home/ec2-user/app/build/libs/"
+          target: "/home/ec2-user/app/app.jar"
 
       - name: SSH into EC2 and deploy
         uses: appleboy/ssh-action@v0.1.10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,5 @@ jobs:
           script: |
             cd /home/ec2-user/app
             docker-compose down
+            docker-compose build --no-cache
             docker-compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2 with Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2 with Docker
 
 on:
   push:
-    branches: [main, fix]
+    branches: [main, fix/#25-회원로직버그]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,15 +17,11 @@ jobs:
       - name: Build JAR
         run: ./gradlew clean build -x test
 
-      - name: Copy JAR to EC2
-        uses: appleboy/scp-action@v0.1.3
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ec2-user
-          key: ${{ secrets.EC2_KEY }}
-          source: "build/libs/TagCafe-0.0.1-SNAPSHOT.jar"
-          target: "/home/ec2-user/app/"
-          overwrite: true
+      - name: Copy JAR to EC2 manually
+        run: |
+          echo "${{ secrets.EC2_KEY }}" > key.pem
+          chmod 600 key.pem
+          scp -i key.pem -o StrictHostKeyChecking=no build/libs/TagCafe-0.0.1-SNAPSHOT.jar ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/app/
 
       - name: SSH into EC2 and deploy
         uses: appleboy/ssh-action@v0.1.10

--- a/src/main/java/com/Minjin/TagCafe/config/KakaoAuthController.java
+++ b/src/main/java/com/Minjin/TagCafe/config/KakaoAuthController.java
@@ -95,6 +95,10 @@ public class KakaoAuthController {
 
         String kakaoNickname = profile != null ? (String) profile.get("nickname") : "Unknown";
         String email = (String) kakaoAccount.get("email");
+        if (email == null || email.isBlank()) {
+            logger.error("❌ 이메일 정보가 없습니다. 카카오 계정에 이메일이 등록되어 있는지 확인하세요.");
+            return new RedirectView("https://tagcafe.site/error?message=이메일 정보를 가져올 수 없습니다.");
+        }
 
         logger.info("✅ 카카오 로그인 성공! 닉네임: {}, 이메일: {}", kakaoNickname, email);
 

--- a/src/main/java/com/Minjin/TagCafe/controller/UserController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/UserController.java
@@ -2,6 +2,7 @@ package com.Minjin.TagCafe.controller;
 
 import com.Minjin.TagCafe.dto.NicknameRequest;
 import com.Minjin.TagCafe.entity.User;
+import com.Minjin.TagCafe.repository.SavedCafeRepository;
 import com.Minjin.TagCafe.repository.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,6 +27,7 @@ import java.util.Optional;
 @CrossOrigin(origins = "https://tagcafe.site", allowCredentials = "true")
 public class UserController {
     private final UserRepository userRepository;
+    private final SavedCafeRepository savedCafeRepository;
 
     @Value("${kakao.client.id}")
     private String kakaoClientId;
@@ -53,6 +55,7 @@ public class UserController {
         Optional<User> userOptional = userRepository.findByEmail(email);
 
         if (userOptional.isPresent()) {
+            savedCafeRepository.deleteAll(savedCafeRepository.findByUser(userOptional.get()));
             userRepository.delete(userOptional.get());
 
             // ✅ 세션 무효화

--- a/src/main/java/com/Minjin/TagCafe/controller/UserController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/UserController.java
@@ -16,6 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -78,7 +80,8 @@ public class UserController {
             // ✅ 카카오 로그아웃 URL 반환
             Map<String, String> response = new HashMap<>();
             response.put("message", "회원 탈퇴 성공");
-            response.put("logoutUrl", "https://kauth.kakao.com/oauth/logout?client_id=" + kakaoClientId + "&logout_redirect_uri=https://tagcafe.site");
+            String encodedRedirectUri = URLEncoder.encode("https://tagcafe.site", StandardCharsets.UTF_8);
+            response.put("logoutUrl", "https://kauth.kakao.com/oauth/logout?client_id=" + kakaoClientId + "&logout_redirect_uri=" + encodedRedirectUri);
 
             return ResponseEntity.ok(response);
         } else {


### PR DESCRIPTION
### 1. 회원로직 재검

1️⃣ redirect URI 인코딩 수정

2️⃣ savedCafe 선삭제 후 탈퇴

3️⃣ 카톡로그인 email null값으로 들어옴→동의 안되어있어서 그럼
→ scope에 빠져있어서 Dockerfile에 추가
 `수정코드`
`Dspring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email \`

4️⃣ Logout Redirect URI  카카오 디벨로퍼에 추가 완료
<br>
<br>


### 2. EC2 부담 감소위한 deploy.yml 수정방안 적용완료

**✅ 1.빌드를 로컬(GitHub Actions)에서 하고, EC2에는 결과물만 전달**
**✅ 2. jar 파일 경로 문제 수정**
**✅ 3. jar 파일 EC2로 전송**
**✅ 4. Dockerfile 수정**



항목 | 기존 방식 | 개선 방식
-- | -- | --
빌드 위치 | EC2 내부에서 ./gradlew build | GitHub Actions에서 빌드 후 EC2로 복사
부하 발생 위치 | EC2 (CPU 부담) | GitHub Actions (EC2는 실행만)
Docker build | EC2에서 직접 수행 | GitHub Actions에서 수행 후 docker save


<br>

<br>

### **✔️ 바뀌는 흐름**

1. **GitHub Actions에서 JAR 빌드**
2. 빌드된 JAR 파일만 EC2로 전송
3. EC2는 docker-compose up만 수행 (--build 없음)
4. Dockerfile은 이미 JAR 경로를 COPY하는 구조여야 함



