### PR TITLE
Feat/#29 카페삭제관리자페이지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2 with Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, feat/#29-카페삭제관리자페이지]
 
 jobs:
   deploy:

--- a/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
+++ b/src/main/java/com/Minjin/TagCafe/controller/CafeController.java
@@ -200,9 +200,38 @@ public class CafeController {
 
     @Operation(summary = "admin - 삭제 가능한 카페 목록 조회", description = "삭제할 수 있는 카페들의 전체 목록을 반환합니다.")
     @GetMapping("/admin/delete-cafe")
-    public ResponseEntity<List<Cafe>> getCafesForDeletion() {
+    public ResponseEntity<List<CafeDto>> getCafesForDeletion() {
         List<Cafe> cafes = cafeRepository.findAll();
-        return ResponseEntity.ok(cafes);
+
+        List<CafeDto> dtos = cafes.stream().map(cafe -> {
+            List<String> imageUrls = cafe.getImages().stream()
+                    .map(CafeImage::getImageUrl)
+                    .toList();
+
+
+            return new CafeDto(
+                    cafe.getCafeId(),
+                    cafe.getKakaoPlaceId(),
+                    cafe.getCafeName(),
+                    cafe.getLatitude(),
+                    cafe.getLongitude(),
+                    cafe.getAddress(),
+                    cafe.getPhoneNumber(),
+                    cafe.getWebsiteUrl(),
+                    cafe.getUpdateAt(),
+                    cafe.getAverageRating(),
+                    cafe.getOpeningHours(),
+                    cafe.getWifi(),
+                    cafe.getOutlets(),
+                    cafe.getDesk(),
+                    cafe.getRestroom(),
+                    cafe.getParking(),
+                    null,
+                    imageUrls
+            );
+        }).toList();
+
+        return ResponseEntity.ok(dtos);
     }
 
     // 모든 카페 조회 API 추가


### PR DESCRIPTION
### Pull request
⛳️ 작업한 브랜치
- <prefix>#29

👷 작업한 내용
- 관리자페이지-카페삭제

### 스크린샷
|기능|스크린샷|
|---|------|
|카페삭제 (관리자페이지)|<img width="352" alt="image" src="https://github.com/user-attachments/assets/699a2866-fa24-4bd9-900e-3d6dc49196f9" />|

### Comment
`/admin/delete-cafe`  로 접속하시면 됩니당
✅ 카페삭제시 해당 카페와 연관된 CafeImage, ReportedCafe, Review, SavedCafe가 모두 삭제되도록  Cafe 엔티티에 `@OneToMany` Cascade 추가하였습니다
✅ CafeDTO를 사용하여 순환 참조로 인한 JSON 직렬화 실패가 일어나지 않도록 했습니다

📍 MySql에서 직접 쿼리로 지우려면 db에 따로 on delete로직을 추가해야하는데, 불필요하다고 생각되어 이 부분은 하지 않았습니다! 따라서 카페를 삭제할때는 쿼리가 아닌 관리자페이지에 접속하여서 삭제하셔야 합니다

### 관련 이슈
- <#29>